### PR TITLE
Optimize hero performance and defer analytics loading

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,8 +45,8 @@ const nextConfig: NextConfig = {
 	},
 
 	// * Add redirect from /careers to external Zoho Recruit careers page
-	async redirects() {
-		return [
+        async redirects() {
+                return [
 			{
 				source: "/projects",
 				destination: "/portfolio",
@@ -97,8 +97,39 @@ const nextConfig: NextConfig = {
 					"https://cal.com/cyber-oni-solutions-inc/investor-pitch-deck-deal-scale",
 				permanent: true,
 			},
-		];
-	},
+                ];
+        },
+        async headers() {
+                return [
+                        {
+                                source: "/_next/static/:path*",
+                                headers: [
+                                        {
+                                                key: "Cache-Control",
+                                                value: "public, max-age=31536000, immutable",
+                                        },
+                                ],
+                        },
+                        {
+                                source: "/_next/image",
+                                headers: [
+                                        {
+                                                key: "Cache-Control",
+                                                value: "public, max-age=31536000, immutable",
+                                        },
+                                ],
+                        },
+                        {
+                                source: "/:all*(svg|png|jpg|jpeg|gif|webp|avif|woff2)",
+                                headers: [
+                                        {
+                                                key: "Cache-Control",
+                                                value: "public, max-age=2592000, must-revalidate",
+                                        },
+                                ],
+                        },
+                ];
+        },
 };
 
 export default nextConfig;

--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -1,0 +1,21 @@
+export default function Head() {
+	return (
+		<>
+			<link
+				rel="preconnect"
+				href="https://js.stripe.com"
+				crossOrigin="anonymous"
+			/>
+			<link
+				rel="preconnect"
+				href="https://m.stripe.network"
+				crossOrigin="anonymous"
+			/>
+			<link
+				rel="preconnect"
+				href="https://js.zohocdn.com"
+				crossOrigin="anonymous"
+			/>
+		</>
+	);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,30 +1,25 @@
 "use client";
 import "../index.css";
-import { Analytics } from "@/components/analytics/Analytics";
 import { PageLayout } from "@/components/layout/PageLayout";
-import GAAnalyticsProvider from "@/components/providers/GAAnalyticsProvider";
+import { DeferredThirdParties } from "@/components/providers/DeferredThirdParties";
 import NextAuthProvider from "@/components/providers/NextAuthProvider";
 import LoadingAnimation from "@/components/ui/loading-animation";
 import { Toaster } from "@/components/ui/toaster";
 import BodyThemeSync from "@/contexts/BodyThemeSync";
 import { ThemeProvider } from "@/contexts/theme-context";
-import { MicrosoftClarityScript } from "@/utils/clarity/ClarityScript";
-import { renderOpenGraphMeta } from "@/utils/seo/seo";
-import { defaultSeo } from "@/utils/seo/staticSeo";
+import { monoFont, sansFont } from "@/styles/fonts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import Script from "next/script";
 import { Suspense } from "react";
-import { metadata } from "./metadata";
 
 const queryClient = new QueryClient();
 
-const { ZOHOSALESIQ_WIDGETCODE } = process.env;
+const { ZOHOSALESIQ_WIDGETCODE, NEXT_PUBLIC_CLARITY_PROJECT_ID } = process.env;
 
 export default function RootLayout({
 	children,
 }: { children: React.ReactNode }) {
 	return (
-		<html lang="en">
+		<html lang="en" className={`${sansFont.variable} ${monoFont.variable}`}>
 			<body className="theme-cyberoni min-h-screen bg-background font-sans antialiased">
 				<ThemeProvider>
 					<BodyThemeSync />
@@ -35,24 +30,10 @@ export default function RootLayout({
 								<PageLayout>{children}</PageLayout>
 							</QueryClientProvider>
 						</NextAuthProvider>
-						<Analytics />
-						<GAAnalyticsProvider />
-						<MicrosoftClarityScript projectId="sttpn4xwgd" />
 					</Suspense>
-					{/* Zoho SalesIQ direct embed */}
-					<Script
-						id="zsiq-init"
-						strategy="afterInteractive"
-						dangerouslySetInnerHTML={{
-							__html:
-								"window.$zoho=window.$zoho || {}; $zoho.salesiq=$zoho.salesiq||{ready:function(){}};",
-						}}
-					/>
-					<Script
-						id="zsiqscript"
-						strategy="afterInteractive"
-						src="https://salesiq.zohopublic.com/widget?wc=siq7b1a5f3f6a15e414fcb16d6c1373946d677d54b16f2302c3baca23636aa89295"
-						defer
+					<DeferredThirdParties
+						clarityProjectId={NEXT_PUBLIC_CLARITY_PROJECT_ID}
+						zohoWidgetCode={ZOHOSALESIQ_WIDGETCODE}
 					/>
 				</ThemeProvider>
 			</body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import AboutUsSection from "@/components/about/AboutUsSection";
 import CaseStudyGrid from "@/components/case-studies/CaseStudyGrid";
+import { ViewportLazy } from "@/components/common/ViewportLazy";
 import ContactForm from "@/components/contact/form/ContactForm";
 import TrustedByScroller from "@/components/contact/utils/TrustedByScroller";
 import Faq from "@/components/faq";
@@ -7,7 +8,6 @@ import { BlogPreview } from "@/components/home/BlogPreview";
 import ClientBento from "@/components/home/ClientBento";
 import UpcomingFeatures from "@/components/home/FeatureVote";
 import Pricing from "@/components/home/Pricing";
-import Projects from "@/components/home/Projects";
 import Services from "@/components/home/Services";
 import Testimonials from "@/components/home/Testimonials";
 import HeroSessionMonitorClientWithModal from "@/components/home/heros/HeroSessionMonitorClientWithModal";
@@ -61,9 +61,7 @@ const Index = async ({
 		? resolvedSearchParams.page[0]
 		: resolvedSearchParams.page;
 	// Get the current page from the query string (SSR-friendly, Next.js style)
-	const currentPage = pageParam
-		? Number.parseInt(pageParam, 10) || 1
-		: 1;
+	const currentPage = pageParam ? Number.parseInt(pageParam, 10) || 1 : 1;
 
 	// Paginate the case studies
 	const paginatedCaseStudies = paginate(
@@ -95,45 +93,62 @@ const Index = async ({
 				]}
 			/>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<UpcomingFeatures />
+			<ViewportLazy>
+				<UpcomingFeatures />
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			{/* Pass only paginated case studies to the grid for performance and UX */}
-			<CaseStudyGrid
-				caseStudies={caseStudies}
-				limit={3}
-				showViewAllButton
-				showCategoryFilter={false}
-			/>
+			<ViewportLazy>
+				<CaseStudyGrid
+					caseStudies={caseStudies}
+					limit={3}
+					showViewAllButton
+					showCategoryFilter={false}
+				/>
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<Testimonials
-				testimonials={generalDealScaleTestimonials}
-				title={"What Our Clients Say"}
-				subtitle={
-					"Hear from our clients about their experiences with our services"
-				}
-			/>
+			<ViewportLazy>
+				<Testimonials
+					testimonials={generalDealScaleTestimonials}
+					title={"What Our Clients Say"}
+					subtitle={
+						"Hear from our clients about their experiences with our services"
+					}
+				/>
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<Faq
-				title="Frequently Asked Questions"
-				subtitle="Find answers to common questions about our services, process, and technology expertise."
-				faqItems={faqItems}
-			/>
+			<ViewportLazy>
+				<Faq
+					title="Frequently Asked Questions"
+					subtitle="Find answers to common questions about our services, process, and technology expertise."
+					faqItems={faqItems}
+				/>
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<Pricing
-				title={"Our Pricing"}
-				subtitle={"Lock In Pilot Pricing For 5 Years!"}
-				plans={PricingPlans}
-			/>
+			<ViewportLazy>
+				<Pricing
+					title={"Our Pricing"}
+					subtitle={"Lock In Pilot Pricing For 5 Years!"}
+					plans={PricingPlans}
+				/>
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<AboutUsSection />
+			<ViewportLazy>
+				<AboutUsSection />
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<ClientBento />
+			<ViewportLazy>
+				<ClientBento />
+			</ViewportLazy>
 			<Separator className="mx-auto my-16 max-w-7xl border-white/10" />
-			<BlogPreview title="Latest Blogs" posts={posts} />
+			<ViewportLazy>
+				<BlogPreview title="Latest Blogs" posts={posts} />
+			</ViewportLazy>
 			<Separator className="mx-auto mt-16 max-w-7xl border-white/10" />
-			<div className="flex items-center justify-center py-5 lg:col-span-7">
-				<ContactForm />
-			</div>
+			<ViewportLazy>
+				<div className="flex items-center justify-center py-5 lg:col-span-7">
+					<ContactForm />
+				</div>
+			</ViewportLazy>
 		</>
 	);
 };

--- a/src/components/case-studies/CaseStudyGrid.tsx
+++ b/src/components/case-studies/CaseStudyGrid.tsx
@@ -115,6 +115,7 @@ const CaseStudyGrid: React.FC<CaseStudyGridProps> = ({
 												alt={study.title}
 												fill
 												style={{ objectFit: "cover" }}
+												sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw"
 												className="transition-transform duration-500 group-hover:scale-105"
 											/>
 										</div>

--- a/src/components/common/ViewportLazy.tsx
+++ b/src/components/common/ViewportLazy.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+
+type ViewportLazyProps = {
+	children: ReactNode;
+	rootMargin?: string;
+};
+
+export function ViewportLazy({
+	children,
+	rootMargin = "256px",
+}: ViewportLazyProps) {
+	const [isVisible, setIsVisible] = useState(false);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (isVisible) return;
+
+		const node = containerRef.current;
+		if (!node) return;
+
+		if (!("IntersectionObserver" in window)) {
+			setIsVisible(true);
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						setIsVisible(true);
+					}
+				});
+			},
+			{ rootMargin },
+		);
+
+		observer.observe(node);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [isVisible, rootMargin]);
+
+	return <div ref={containerRef}>{isVisible ? children : null}</div>;
+}

--- a/src/components/home/heros/HeroSessionMonitor.tsx
+++ b/src/components/home/heros/HeroSessionMonitor.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import DemoTabs from "@/components/deal_scale/demo/tabs/DemoTabs";
 import demoTranscript from "@/data/transcripts";
 import { cn } from "@/lib/utils";
 import type { Transcript } from "@/types/transcript";
 import { motion } from "framer-motion";
-import { useTheme } from "next-themes";
+import dynamic from "next/dynamic";
 import type { StaticImageData } from "next/image";
-import { useEffect, useState } from "react";
+
+const DemoTabs = dynamic(
+	() => import("@/components/deal_scale/demo/tabs/DemoTabs"),
+	{
+		loading: () => <HeroDemoSkeleton />,
+		ssr: false,
+	},
+);
 
 // Define words to highlight with their corresponding gradient colors
 const HIGHLIGHT_WORDS = [
@@ -109,30 +115,17 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 	isMobile = false,
 	backgroundImage,
 }) => {
-	const { theme } = useTheme();
-	const [mounted, setMounted] = useState(false);
-
-	// Only render on client to avoid hydration mismatch
-	useEffect(() => {
-		setMounted(true);
-	}, []);
-
-	if (!mounted) {
-		return (
-			<div className={cn("relative overflow-hidden", className)}>
-				<div className="h-[500px] w-full animate-pulse bg-muted/20" />
-			</div>
-		);
-	}
 	return (
-		<div
+		<section
 			className={cn(
 				"mx-auto mt-16 mb-8 grid w-full max-w-[90rem] items-center gap-6 px-4 sm:mt-24 sm:mb-16 sm:px-6 lg:my-16 lg:grid-cols-2 lg:gap-8 lg:px-8",
+				"min-h-[640px] lg:min-h-[720px]",
 				className,
 			)}
+			aria-labelledby="hero-heading"
 		>
 			{/* Text Content */}
-			<div className="text-center sm:text-left md:mt-2">
+			<div className="flex h-full flex-col justify-center text-center sm:text-left md:mt-2">
 				{badge && (
 					<motion.span
 						initial={{ opacity: 0, y: 20 }}
@@ -143,7 +136,10 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 						{badge}
 					</motion.span>
 				)}
-				<h1 className="mx-auto animate-fade-in font-bold text-3xl text-glow sm:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
+				<h1
+					id="hero-heading"
+					className="mx-auto font-bold text-3xl text-glow sm:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl"
+				>
 					{headline}
 				</h1>
 				<span className="mx-auto my-2 block bg-gradient-to-r from-primary to-focus bg-clip-text py-2 font-bold text-3xl text-transparent sm:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl">
@@ -191,11 +187,33 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 			</div>
 
 			{/* Session Monitor Carousel */}
-			<div className="relative w-full max-w-4xl">
-				<DemoTabs />
+			<div className="relative flex w-full max-w-4xl items-stretch justify-center">
+				<div className="relative flex w-full max-w-4xl items-stretch">
+					<div className="flex min-h-[420px] w-full items-center justify-center rounded-3xl border border-white/10 bg-black/20 p-4 shadow-[0_20px_80px_rgba(15,23,42,0.25)] backdrop-blur lg:min-h-[480px] dark:border-white/5">
+						<DemoTabs />
+					</div>
+				</div>
 			</div>
-		</div>
+		</section>
 	);
 };
 
 export default HeroSessionMonitor;
+
+function HeroDemoSkeleton() {
+	return (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-4">
+			<div className="h-12 w-full max-w-lg animate-pulse rounded-full bg-white/5" />
+			<div className="flex w-full max-w-3xl flex-col gap-3">
+				{Array.from({ length: 4 }).map((_, index) => (
+					<div
+						// biome-ignore lint/suspicious/noArrayIndexKey: static placeholder content
+						key={index}
+						className="h-10 animate-pulse rounded-lg bg-white/5"
+					/>
+				))}
+			</div>
+			<div className="h-64 w-full max-w-3xl animate-pulse rounded-2xl bg-white/5" />
+		</div>
+	);
+}

--- a/src/components/home/heros/HeroSessionMonitorClientWithModal.tsx
+++ b/src/components/home/heros/HeroSessionMonitorClientWithModal.tsx
@@ -15,13 +15,11 @@ export default function HeroSessionMonitorClientWithModal() {
 	const [sessionReset, setSessionReset] = useState(() => () => {});
 
 	const handleCallEnd = () => {
-		console.log("handleCallEnd triggered in parent");
 		setModalContent("complete");
 		setShowCallCompleteModal(true);
 	};
 
 	const handleTransfer = () => {
-		console.log("handleTransfer triggered in parent");
 		setModalContent("transfer");
 		setShowCallCompleteModal(true);
 	};

--- a/src/components/providers/DeferredThirdParties.tsx
+++ b/src/components/providers/DeferredThirdParties.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+const Analytics = dynamic(() => import("@/components/analytics/Analytics"), {
+	ssr: false,
+});
+const GAAnalyticsProvider = dynamic(() => import("./GAAnalyticsProvider"), {
+	ssr: false,
+});
+const MicrosoftClarityScript = dynamic(
+	() =>
+		import("@/utils/clarity/ClarityScript").then(
+			(mod) => mod.MicrosoftClarityScript,
+		),
+	{ ssr: false },
+);
+
+const INTERACTION_EVENTS: Array<keyof WindowEventMap> = [
+	"scroll",
+	"pointerdown",
+	"keydown",
+];
+
+function useDeferredLoad() {
+	const [shouldLoad, setShouldLoad] = useState(false);
+
+	useEffect(() => {
+		if (shouldLoad || typeof window === "undefined") {
+			return;
+		}
+
+		let cancelled = false;
+
+		const enable = () => {
+			if (!cancelled) {
+				setShouldLoad(true);
+			}
+		};
+
+		const idle = () => {
+			if ("requestIdleCallback" in window) {
+				window.requestIdleCallback(() => enable(), { timeout: 2000 });
+			} else {
+				window.setTimeout(() => enable(), 1200);
+			}
+		};
+
+		if (document.readyState === "complete") {
+			idle();
+		} else {
+			window.addEventListener("load", idle, { once: true });
+		}
+
+		INTERACTION_EVENTS.forEach((eventName) => {
+			window.addEventListener(eventName, enable, { once: true, passive: true });
+		});
+
+		return () => {
+			cancelled = true;
+			window.removeEventListener("load", idle);
+			INTERACTION_EVENTS.forEach((eventName) => {
+				window.removeEventListener(eventName, enable);
+			});
+		};
+	}, [shouldLoad]);
+
+	return shouldLoad;
+}
+
+declare global {
+	interface Window {
+		$zoho?: {
+			salesiq?: {
+				ready: () => void;
+			};
+		};
+	}
+}
+
+interface DeferredThirdPartiesProps {
+	clarityProjectId?: string;
+	zohoWidgetCode?: string;
+}
+
+export function DeferredThirdParties({
+	clarityProjectId,
+	zohoWidgetCode,
+}: DeferredThirdPartiesProps) {
+	const shouldLoad = useDeferredLoad();
+
+	useEffect(() => {
+		if (!shouldLoad || !zohoWidgetCode || typeof window === "undefined") {
+			return;
+		}
+
+		if (document.getElementById("zsiqscript")) {
+			return;
+		}
+
+		window.$zoho = window.$zoho || {};
+		window.$zoho.salesiq = window.$zoho.salesiq || { ready: () => undefined };
+
+		const script = document.createElement("script");
+		script.id = "zsiqscript";
+		script.src = `https://salesiq.zohopublic.com/widget?wc=${zohoWidgetCode}`;
+		script.async = true;
+		script.defer = true;
+		document.body.appendChild(script);
+
+		return () => {
+			script.remove();
+		};
+	}, [shouldLoad, zohoWidgetCode]);
+
+	if (!shouldLoad) {
+		return null;
+	}
+
+	return (
+		<>
+			<Analytics />
+			<GAAnalyticsProvider />
+			<MicrosoftClarityScript projectId={clarityProjectId} />
+		</>
+	);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,8 +3,19 @@
 @tailwind utilities;
 
 @layer base {
-	.theme-cyberoni {
-		--focus: 262 83% 66%; /* purple accent for focus */
+        :root {
+                font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system,
+                        BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        code,
+        pre {
+                font-family: var(--font-mono), ui-monospace, SFMono-Regular,
+                        Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+
+        .theme-cyberoni {
+                --focus: 262 83% 66%; /* purple accent for focus */
 		--tertiary: 186 100% 60%; /* cyber-neon */
 		--tertiary-foreground: 210 40% 98%;
 		--background-dark: 225 30% 3%; /* darker shade for dark theme */

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,15 @@
+import { JetBrains_Mono, Manrope } from "next/font/google";
+
+export const sansFont = Manrope({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-sans",
+	weight: ["300", "400", "500", "600", "700"],
+});
+
+export const monoFont = JetBrains_Mono({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-mono",
+	weight: ["400", "500", "600", "700"],
+});


### PR DESCRIPTION
## Summary
- adopt `next/font` hosted typography, wire it through the layout, and add cache headers for long-lived static assets
- introduce deferred third-party loading and viewport-based hydration to limit main-thread work on initial load
- lazy load the hero carousel, add a skeleton placeholder, and tighten image sizing to reduce layout shift

## Testing
- pnpm lint *(fails: repository contains pre-existing Biome `noExplicitAny` violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bf6c7580832986250a890ff3660f