### PR TITLE
Fix hero session monitor animation and defer third-party scripts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { MicrosoftClarityScript } from "@/utils/clarity/ClarityScript";
 import { renderOpenGraphMeta } from "@/utils/seo/seo";
 import { defaultSeo } from "@/utils/seo/staticSeo";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import dynamic from "next/dynamic";
 import Script from "next/script";
 import { Suspense } from "react";
 import { metadata } from "./metadata";
@@ -19,6 +20,11 @@ import { metadata } from "./metadata";
 const queryClient = new QueryClient();
 
 const { ZOHOSALESIQ_WIDGETCODE } = process.env;
+
+const DeferredThirdParties = dynamic(
+	() => import("@/components/providers/DeferredThirdParties"),
+	{ ssr: false, loading: () => null },
+);
 
 export default function RootLayout({
 	children,
@@ -38,11 +44,13 @@ export default function RootLayout({
 						<Analytics />
 						<GAAnalyticsProvider />
 						<MicrosoftClarityScript projectId="sttpn4xwgd" />
+						<DeferredThirdParties />
 					</Suspense>
 					{/* Zoho SalesIQ direct embed */}
 					<Script
 						id="zsiq-init"
 						strategy="afterInteractive"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: Third-party embed script is trusted
 						dangerouslySetInnerHTML={{
 							__html:
 								"window.$zoho=window.$zoho || {}; $zoho.salesiq=$zoho.salesiq||{ready:function(){}};",

--- a/src/components/home/heros/HeroSessionMonitor.tsx
+++ b/src/components/home/heros/HeroSessionMonitor.tsx
@@ -17,6 +17,11 @@ const HIGHLIGHT_WORDS = [
 	{ word: "monitor", gradient: "from-emerald-500 to-teal-400" },
 ];
 
+const animateIn = {
+	hidden: { opacity: 0, y: 20 },
+	visible: { opacity: 1, y: 0 },
+};
+
 export interface HeroSessionMonitorProps {
 	transcript?: Transcript;
 	className?: string;
@@ -135,8 +140,9 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 			<div className="text-center sm:text-left md:mt-2">
 				{badge && (
 					<motion.span
-						initial={{ opacity: 0, y: 20 }}
-						animate={{ opacity: 1, y: 0 }}
+						variants={animateIn}
+						initial="hidden"
+						animate="visible"
 						transition={{ duration: 0.4, delay: 0.1 }}
 						className="mx-auto mb-4 inline-block rounded-full bg-primary/10 px-4 py-1.5 font-medium text-primary text-sm"
 					>
@@ -155,8 +161,9 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 				</p>
 				{(onCtaClick || onCtaClick2) && (
 					<motion.div
-						initial={{ opacity: 0, y: 20 }}
-						animate={{ opacity: 1, y: 0 }}
+						variants={animateIn}
+						initial="hidden"
+						animate="visible"
 						transition={{ duration: 0.4, delay: 0.4 }}
 						className="mt-10 flex flex-wrap items-center justify-center gap-4 sm:justify-start"
 					>

--- a/src/components/providers/DeferredThirdParties.tsx
+++ b/src/components/providers/DeferredThirdParties.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Script from "next/script";
+import { useEffect, useMemo, useState } from "react";
+
+import { FB_PIXEL_ID, pageView } from "@/utils/seo/fbpixel";
+
+type IdleCallbackHandle = number | null;
+
+declare global {
+	interface Window {
+		requestIdleCallback?: (
+			callback: IdleRequestCallback,
+			options?: IdleRequestOptions,
+		) => number;
+		cancelIdleCallback?: (handle: number) => void;
+	}
+}
+
+const hasFacebookPixel = Boolean(FB_PIXEL_ID);
+
+const registerIdleCallback = (onIdle: () => void): (() => void) | undefined => {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+
+	let idleHandle: IdleCallbackHandle = null;
+	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+	const trigger = () => {
+		idleHandle = null;
+		timeoutHandle = null;
+		onIdle();
+	};
+
+	if (window.requestIdleCallback) {
+		idleHandle = window.requestIdleCallback(trigger, { timeout: 1500 });
+		return () => {
+			if (idleHandle !== null && window.cancelIdleCallback) {
+				window.cancelIdleCallback(idleHandle);
+			}
+		};
+	}
+
+	timeoutHandle = window.setTimeout(trigger, 1200);
+	return () => {
+		if (timeoutHandle !== null) {
+			clearTimeout(timeoutHandle);
+		}
+	};
+};
+
+export default function DeferredThirdParties() {
+	const pathname = usePathname();
+	const [shouldLoad, setShouldLoad] = useState(false);
+
+	useEffect(() => {
+		const cancelIdle = registerIdleCallback(() => setShouldLoad(true));
+		return () => {
+			if (cancelIdle) cancelIdle();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!shouldLoad || !hasFacebookPixel) {
+			return;
+		}
+
+		const trackedPath =
+			pathname ??
+			(typeof window !== "undefined" ? window.location.pathname : undefined);
+
+		pageView(trackedPath ? { pathname: trackedPath } : undefined);
+	}, [pathname, shouldLoad]);
+
+	const pixelMarkup = useMemo(() => {
+		if (!shouldLoad || !hasFacebookPixel) {
+			return null;
+		}
+
+		const pixelId = FB_PIXEL_ID ?? "";
+
+		const bootstrap = `!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?\n                        n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;\n                        n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;\n                        t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s);\n                }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');`;
+
+		const initSnippet = `window.fbq('init', '${pixelId}'); window.fbq('track', 'PageView');`;
+
+		return (
+			<>
+				<Script
+					id="fb-pixel-bootstrap"
+					strategy="afterInteractive"
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: Third-party bootstrap script is trusted
+					dangerouslySetInnerHTML={{ __html: bootstrap }}
+				/>
+				<Script
+					id="fb-pixel-init"
+					strategy="afterInteractive"
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: Third-party initialization script is trusted
+					dangerouslySetInnerHTML={{ __html: initSnippet }}
+				/>
+			</>
+		);
+	}, [shouldLoad]);
+
+	if (!pixelMarkup) {
+		return null;
+	}
+
+	return pixelMarkup;
+}

--- a/src/utils/__tests__/components/HeroSessionMonitor.test.tsx
+++ b/src/utils/__tests__/components/HeroSessionMonitor.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+
+import HeroSessionMonitor from "@/components/home/heros/HeroSessionMonitor";
+
+jest.mock("next-themes", () => ({
+	useTheme: () => ({ theme: "light", setTheme: () => undefined }),
+}));
+
+jest.mock("@/components/deal_scale/demo/tabs/DemoTabs", () => () => (
+	<div data-testid="demo-tabs" />
+));
+
+describe("HeroSessionMonitor", () => {
+	it("renders highlight content once mounted", async () => {
+		render(
+			<HeroSessionMonitor
+				headline="Test Headline"
+				subheadline="A helpful summary"
+				highlight="Important Highlight"
+				ctaLabel="Primary CTA"
+				onCtaClick={() => undefined}
+			/>,
+		);
+
+		expect(await screen.findByText("Test Headline")).toBeInTheDocument();
+		expect(screen.getByText("Important Highlight")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Primary CTA" }),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("demo-tabs")).toBeInTheDocument();
+	});
+});

--- a/src/utils/__tests__/providers/DeferredThirdParties.test.ts
+++ b/src/utils/__tests__/providers/DeferredThirdParties.test.ts
@@ -1,0 +1,6 @@
+describe("DeferredThirdParties module", () => {
+	it("exposes a default export that can be dynamically imported", async () => {
+		const mod = await import("@/components/providers/DeferredThirdParties");
+		expect(typeof mod.default).toBe("function");
+	});
+});

--- a/src/utils/seo/fbpixel.ts
+++ b/src/utils/seo/fbpixel.ts
@@ -6,10 +6,10 @@ declare global {
 
 export const FB_PIXEL_ID = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID;
 
-export const pageView = () => {
-	if (window.fbq) window.fbq("track", "PageView");
+export const pageView = (properties?: Record<string, unknown>) => {
+	if (window.fbq) window.fbq("track", "PageView", properties);
 };
 
-export const event = (name: string, options = {}) => {
+export const event = (name: string, options: Record<string, unknown> = {}) => {
 	if (window.fbq) window.fbq("track", name, options);
 };


### PR DESCRIPTION
## Summary
- restore the hero session monitor motion variants so the badge and CTA animations use a shared animateIn definition
- add a DeferredThirdParties provider that lazily boots the Facebook Pixel and wire it into the root layout
- extend the Facebook pixel helper and add regression tests covering the hero monitor render path and deferred provider export

## Testing
- pnpm test *(fails: existing Jest configuration cannot parse ESM setup files)*

------
https://chatgpt.com/codex/tasks/task_e_68e496e1b9488329a7f08b0dcf65fbd7