### PR TITLE
Fix HeroSessionMonitor animation regression

### DIFF
--- a/src/components/home/heros/HeroSessionMonitor.tsx
+++ b/src/components/home/heros/HeroSessionMonitor.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import demoTranscript from "@/data/transcripts";
 import { cn } from "@/lib/utils";
 import type { Transcript } from "@/types/transcript";
@@ -14,17 +16,23 @@ const HIGHLIGHT_WORDS = [
 ];
 
 // Animation variants for framer-motion
-const animateIn = (delay = 0) => ({
-	initial: { opacity: 0, y: 20 },
-	animate: { opacity: 1, y: 0 },
-	transition: { duration: 0.6, delay },
-});
+const BADGE_ANIMATION_PROPS = {
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.6, delay: 0.1 },
+} as const;
 
-interface HeroSessionMonitorProps {
-	transcript?: Transcript;
-	className?: string;
-	headline?: string;
-	subheadline?: string;
+const CTA_ANIMATION_PROPS = {
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.6, delay: 0.4 },
+} as const;
+
+export interface HeroSessionMonitorProps {
+        transcript?: Transcript;
+        className?: string;
+        headline?: string;
+        subheadline?: string;
 	highlight?: string;
 	highlightWords?: Array<{ word: string; gradient: string }>;
 	ctaLabel?: string;
@@ -43,7 +51,7 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 	transcript = demoTranscript,
 	className,
 	headline,
-	subheadline,
+        subheadline = "",
 	highlight = "Appointments Delivered",
 	highlightWords = HIGHLIGHT_WORDS,
 	ctaLabel = "Get Started",
@@ -130,14 +138,16 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 		>
 			{/* Text Content */}
 			<div className="flex h-full flex-col justify-center text-center sm:text-left md:mt-2">
-				{badge && (
-					<motion.span
-						{...animateIn(0.1)}
-						className="mx-auto mb-4 inline-block rounded-full bg-primary/10 px-4 py-1.5 font-medium text-primary text-sm"
-					>
-						{badge}
-					</motion.span>
-				)}
+                                {badge && (
+                                        <motion.span
+                                                initial={BADGE_ANIMATION_PROPS.initial}
+                                                animate={BADGE_ANIMATION_PROPS.animate}
+                                                transition={BADGE_ANIMATION_PROPS.transition}
+                                                className="mx-auto mb-4 inline-block rounded-full bg-primary/10 px-4 py-1.5 font-medium text-primary text-sm"
+                                        >
+                                                {badge}
+                                        </motion.span>
+                                )}
 				<h1
 					id="hero-heading"
 					className="mx-auto font-bold text-3xl text-glow sm:text-4xl lg:text-5xl xl:text-6xl 2xl:text-7xl"
@@ -151,11 +161,13 @@ const HeroSessionMonitor: React.FC<HeroSessionMonitorProps> = ({
 				<p className="mx-auto mb-6 max-w-md text-base text-black sm:mb-10 sm:text-lg lg:max-w-xl lg:text-xl xl:max-w-2xl dark:text-white/70">
 					<HighlightedText text={subheadline} highlightWords={highlightWords} />
 				</p>
-				{(onCtaClick || onCtaClick2) && (
-					<motion.div
-						{...animateIn(0.4)}
-						className="mt-10 flex flex-wrap items-center justify-center gap-4 sm:justify-start"
-					>
+                                {(onCtaClick || onCtaClick2) && (
+                                        <motion.div
+                                                initial={CTA_ANIMATION_PROPS.initial}
+                                                animate={CTA_ANIMATION_PROPS.animate}
+                                                transition={CTA_ANIMATION_PROPS.transition}
+                                                className="mt-10 flex flex-wrap items-center justify-center gap-4 sm:justify-start"
+                                        >
 						{onCtaClick && (
 							<button
 								onClick={onCtaClick}

--- a/src/components/home/heros/__tests__/HeroSessionMonitor.test.tsx
+++ b/src/components/home/heros/__tests__/HeroSessionMonitor.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import HeroSessionMonitor from "../HeroSessionMonitor";
+
+jest.mock("next/dynamic", () => {
+        const React = require("react") as typeof import("react");
+        return {
+                __esModule: true,
+                default: (
+                        _importer: () => Promise<unknown>,
+                        options?: { loading?: React.ComponentType },
+                ) => {
+                        const Loading = options?.loading;
+                        const DynamicComponent = (
+                                props: Record<string, unknown>,
+                        ) => (Loading ? React.createElement(Loading, props) : null);
+                        DynamicComponent.displayName = "DynamicComponentMock";
+                        return DynamicComponent;
+                },
+        };
+});
+
+jest.mock("framer-motion", () => {
+        const React = require("react") as typeof import("react");
+        const createMock = (tag: keyof JSX.IntrinsicElements) =>
+                ({ children, ...props }: { children?: React.ReactNode }) =>
+                        React.createElement(tag, props, children);
+
+        return {
+                motion: {
+                        span: createMock("span"),
+                        div: createMock("div"),
+                },
+        };
+});
+
+describe("HeroSessionMonitor", () => {
+        it("renders badge and CTA buttons without runtime errors", () => {
+                render(
+                        <HeroSessionMonitor
+                                headline="Test headline"
+                                subheadline="Discover real-time insights with analytics"
+                                badge="Beta access"
+                                ctaLabel="Primary CTA"
+                                ctaLabel2="Secondary CTA"
+                                onCtaClick={() => undefined}
+                                onCtaClick2={() => undefined}
+                        />,
+                );
+
+                expect(screen.getByText("Beta access")).toBeInTheDocument();
+                expect(screen.getByText("Primary CTA")).toBeInTheDocument();
+                expect(screen.getByText("Secondary CTA")).toBeInTheDocument();
+        });
+});


### PR DESCRIPTION
## Summary
- convert HeroSessionMonitor to a client component with explicit animation props
- add a regression test to ensure the hero renders without runtime errors when animations are applied

## Testing
- pnpm exec jest src/components/home/heros/__tests__/HeroSessionMonitor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e49cad66088329880733a919fcfe4f